### PR TITLE
xdg-open support + customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ PITA, you may override them, by creating the `~/.config/nwg-panel/preferred-apps
 }
 ```
 
-Use the **right mouse button** open the file with your file manager (see `-fm` argument). The result depends on the
+Use the **right mouse button** to open the file with your file manager (see `-fm` argument). The result depends on the
 file manager you use.
 
 - thunar will open the file location
-- pcmanfm will open the file in its associated program
+- pcmanfm will open the file with its associated program
 - caja won't open anything, except for directories
 
 I've noy yet tried other file managers.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,37 @@ Usage of nwg-drawer:
 
 Edit `~/.config/nwg-panel/drawer.css` to your taste.
 
+## Files
+
+When the search phrase is at least 3 characters long, your XDG user directories are being searched.
+
+![screenshot-03.png](https://scrot.cloud/images/2021/05/30/screenshot-03.png)
+
+Use the **left mouse button** to open a file with the `xdg-open` command. As configuring file associations for it is PITA,
+you may override them, by defining your own definitions in the `~/.config/nwg-panel/preferred-apps.json` file.
+
+### Sample ~/.config/nwg-panel/preferred-apps.json file content
+
+```json
+{
+  "\\.pdf$": "atril",
+  "\\.svg$": "inkscape",
+  "\\.(jpg|png|tiff|gif)$": "feh",
+  "\\.(mp3|ogg|flac|wav|wma)$": "audacious",
+  "\\.(avi|mp4|mkv|mov|wav)$": "mpv",
+  "\\.(doc|docx|xls|xlsx)$": "libreoffice"
+}
+```
+
+Use the **right mouse button** open the file with your file manager (see `-fm` argument). The result depends on the
+file manager you use.
+
+- thunar will open the file location
+- pcmanfm will open the file in its associated program
+- caja won't open anything, except for directories
+
+I've noy yet tried other file managers.
+
 ## Credits
 
 This program uses some great libraries:

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ When the search phrase is at least 3 characters long, your XDG user directories 
 
 ![screenshot-03.png](https://scrot.cloud/images/2021/05/30/screenshot-03.png)
 
-Use the **left mouse button** to open a file with the `xdg-open` command. As configuring file associations for it is PITA,
-you may override them, by defining your own definitions in the `~/.config/nwg-panel/preferred-apps.json` file.
+Use the **left mouse button** to open a file with the `xdg-open` command. As configuring file associations for it is
+PITA, you may override them, by creating the `~/.config/nwg-panel/preferred-apps.json` file with your own definitions.
 
-### Sample ~/.config/nwg-panel/preferred-apps.json file content
+### Sample file content
 
 ```json
 {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "0.1.6"
+const version = "0.1.7"
 
 var (
 	appDirs         []string
@@ -28,6 +28,7 @@ var (
 	pinned          []string
 	src             glib.SourceHandle
 	id2entry        map[string]desktopEntry
+	preferredApps   map[string]interface{}
 )
 
 var categoryNames = [...]string{
@@ -187,6 +188,17 @@ func main() {
 	println(fmt.Sprintf("Found %v desktop files", len(desktopFiles)))
 
 	status = parseDesktopFiles(desktopFiles)
+
+	// For opening files we use xdg-open. As its configuration is PITA, we may override some associations
+	// in the ~/.config/nwg-panel/preferred-apps.json file.
+	paFile := filepath.Join(configDirectory, "preferred-apps.json")
+	preferredApps, err = loadPreferredApps(paFile)
+	if err != nil {
+		println(fmt.Sprintf("Custom associations file %s not found or invalid", paFile))
+	} else {
+		println(fmt.Sprintf("Found %v associations in %s", len(preferredApps), paFile))
+		fmt.Println(preferredApps)
+	}
 
 	// USER INTERFACE
 	gtk.Init(nil)

--- a/main.go
+++ b/main.go
@@ -255,15 +255,6 @@ func main() {
 		gtk.MainQuit()
 	})
 
-	win.Connect("button-release-event", func(sw *gtk.Window, e *gdk.Event) bool {
-		btnEvent := gdk.EventButtonNewFromEvent(e)
-		if btnEvent.Button() == 1 || btnEvent.Button() == 3 {
-			gtk.MainQuit()
-			return true
-		}
-		return false
-	})
-
 	win.Connect("key-press-event", func(window *gtk.Window, event *gdk.Event) bool {
 		key := &gdk.EventKey{Event: event}
 		switch key.KeyVal() {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "0.1.5"
+const version = "0.1.6"
 
 var (
 	appDirs         []string

--- a/tools.go
+++ b/tools.go
@@ -650,8 +650,8 @@ func open(filePath string, xdgOpen bool) {
 		cmd = exec.Command("xdg-open", filePath)
 		// Look for possible custom file association
 		for key, element := range preferredApps {
-			r, _ := regexp.Compile(key)
-			if r.MatchString(filePath) {
+			r, err := regexp.Compile(key)
+			if err == nil && r.MatchString(filePath) {
 				cmd = exec.Command(fmt.Sprintf("%v", element), filePath)
 				break
 			}
@@ -659,7 +659,7 @@ func open(filePath string, xdgOpen bool) {
 	} else {
 		cmd = exec.Command(*fileManager, filePath)
 	}
-	fmt.Println(cmd)
+	fmt.Printf("Executing: %s", cmd)
 	cmd.Start()
 
 	gtk.MainQuit()

--- a/tools.go
+++ b/tools.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -241,6 +244,25 @@ func getAppDirs() []string {
 		}
 	}
 	return dirs
+}
+
+func loadPreferredApps(path string) (map[string]interface{}, error) {
+	jsonFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	var result map[string]interface{}
+	json.Unmarshal([]byte(byteValue), &result)
+
+	if len(result) == 0 {
+		return nil, errors.New("json invalid or empty")
+	}
+
+	return result, nil
 }
 
 func listFiles(dir string) ([]fs.FileInfo, error) {
@@ -622,14 +644,25 @@ func launch(command string, terminal bool) {
 	})
 }
 
-func open(filePath string) {
-	cmd := exec.Command(*fileManager, filePath)
+func open(filePath string, xdgOpen bool) {
+	var cmd *exec.Cmd
+	if xdgOpen {
+		cmd = exec.Command("xdg-open", filePath)
+		// Look for possible custom file association
+		for key, element := range preferredApps {
+			r, _ := regexp.Compile(key)
+			if r.MatchString(filePath) {
+				cmd = exec.Command(fmt.Sprintf("%v", element), filePath)
+				break
+			}
+		}
+	} else {
+		cmd = exec.Command(*fileManager, filePath)
+	}
+	fmt.Println(cmd)
 	cmd.Start()
 
-	glib.TimeoutAdd(uint(150), func() bool {
-		gtk.MainQuit()
-		return false
-	})
+	gtk.MainQuit()
 }
 
 // Returns map output name -> gdk.Monitor

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -387,7 +387,8 @@ func searchUserDir(dir string) {
 		}
 		fileSearchResultFlowBox.Hide()
 
-		statusLabel.SetText(fmt.Sprintf("%v results", fileSearchResultFlowBox.GetChildren().Length()))
+		statusLabel.SetText(fmt.Sprintf("%v results | LMB: xdg-open | RMB: file manager",
+			fileSearchResultFlowBox.GetChildren().Length()))
 		num := uint(fileSearchResultFlowBox.GetChildren().Length() / *fsColumns)
 		fileSearchResultFlowBox.SetMinChildrenPerLine(num + 1)
 		fileSearchResultFlowBox.SetMaxChildrenPerLine(num + 1)
@@ -414,8 +415,16 @@ func setUpUserDirButton(iconName, displayName, entryName string, userDirsMap map
 	}
 	button.SetLabel(displayName)
 
-	button.Connect("clicked", func() {
-		launch(fmt.Sprintf("%s %s", *fileManager, userDirsMap[entryName]), false)
+	button.Connect("button-release-event", func(btn *gtk.Button, e *gdk.Event) bool {
+		btnEvent := gdk.EventButtonNewFromEvent(e)
+		if btnEvent.Button() == 1 {
+			open(userDirsMap[entryName], true)
+			return true
+		} else if btnEvent.Button() == 3 {
+			open(userDirsMap[entryName], false)
+			return true
+		}
+		return false
 	})
 
 	box.PackStart(button, false, true, 0)
@@ -443,8 +452,16 @@ func setUpUserFileSearchResultButton(fileName, filePath string) *gtk.Box {
 		button.SetTooltipText(tooltipText)
 	}
 
-	button.Connect("clicked", func() {
-		open(filePath)
+	button.Connect("button-release-event", func(btn *gtk.Button, e *gdk.Event) bool {
+		btnEvent := gdk.EventButtonNewFromEvent(e)
+		if btnEvent.Button() == 1 {
+			open(filePath, true)
+			return true
+		} else if btnEvent.Button() == 3 {
+			open(filePath, false)
+			return true
+		}
+		return false
 	})
 
 	box.PackStart(button, false, true, 0)


### PR DESCRIPTION
Search -> files: 

- Left Mouse Button opens files with `xdg-open`; additionally you may add own file associations, see [README](https://github.com/nwg-piotr/nwg-drawer/tree/files#files);
- Right Mouse Button opens files with the file manager.

Also:

-  fixed bug terminating the program on search box or category button clicked.