### PR TITLE
use `unknown` icon when one is not available

### DIFF
--- a/uicomponents.go
+++ b/uicomponents.go
@@ -6,9 +6,24 @@ import (
 	"path/filepath"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/gotk3/gotk3/gdk"
 	"github.com/gotk3/gotk3/gtk"
 )
+
+func getImageFromIcon(ico string) (img *gtk.Image, err error) {
+	var pixbuf *gdk.Pixbuf
+	if ico != "" {
+		pixbuf, err = createPixbuf(ico, *iconSize)
+	} else {
+		pixbuf, err = createPixbuf("image-missing", *iconSize)
+	}
+	if err != nil {
+		pixbuf, _ = createPixbuf("unknown", *iconSize)
+	}
+	img, _ = gtk.ImageNewFromPixbuf(pixbuf)
+	return
+}
 
 func setUpPinnedFlowBox() *gtk.FlowBox {
 	if pinnedFlowBox != nil {
@@ -33,12 +48,9 @@ func setUpPinnedFlowBox() *gtk.FlowBox {
 
 			btn, _ := gtk.ButtonNew()
 
-			var img *gtk.Image
-			if entry.Icon != "" {
-				pixbuf, _ := createPixbuf(entry.Icon, *iconSize)
-				img, _ = gtk.ImageNewFromPixbuf(pixbuf)
-			} else {
-				img, _ = gtk.ImageNewFromIconName("image-missing", gtk.ICON_SIZE_INVALID)
+			img, err := getImageFromIcon(entry.Icon)
+			if err != nil {
+				log.Error(err)
 			}
 
 			btn.SetImage(img)
@@ -233,12 +245,9 @@ func flowBoxButton(entry desktopEntry) *gtk.Button {
 	button, _ := gtk.ButtonNew()
 	button.SetAlwaysShowImage(true)
 
-	var img *gtk.Image
-	if entry.Icon != "" {
-		pixbuf, _ := createPixbuf(entry.Icon, *iconSize)
-		img, _ = gtk.ImageNewFromPixbuf(pixbuf)
-	} else {
-		img, _ = gtk.ImageNewFromIconName("image-missing", gtk.ICON_SIZE_INVALID)
+	img, err := getImageFromIcon(entry.Icon)
+	if err != nil {
+		log.Error(err)
 	}
 
 	button.SetImage(img)

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -11,20 +11,6 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-func getImageFromIcon(ico string) (img *gtk.Image, err error) {
-	var pixbuf *gdk.Pixbuf
-	if ico != "" {
-		pixbuf, err = createPixbuf(ico, *iconSize)
-	} else {
-		pixbuf, err = createPixbuf("image-missing", *iconSize)
-	}
-	if err != nil {
-		pixbuf, _ = createPixbuf("unknown", *iconSize)
-	}
-	img, _ = gtk.ImageNewFromPixbuf(pixbuf)
-	return
-}
-
 func setUpPinnedFlowBox() *gtk.FlowBox {
 	if pinnedFlowBox != nil {
 		pinnedFlowBox.Destroy()
@@ -48,10 +34,19 @@ func setUpPinnedFlowBox() *gtk.FlowBox {
 
 			btn, _ := gtk.ButtonNew()
 
-			img, err := getImageFromIcon(entry.Icon)
+			var pixbuf *gdk.Pixbuf
+			var img *gtk.Image
+			var err error
+			if entry.Icon != "" {
+				pixbuf, err = createPixbuf(entry.Icon, *iconSize)
+			} else {
+				pixbuf, err = createPixbuf("image-missing", *iconSize)
+			}
 			if err != nil {
 				log.Error(err)
+				pixbuf, _ = createPixbuf("unknown", *iconSize)
 			}
+			img, _ = gtk.ImageNewFromPixbuf(pixbuf)
 
 			btn.SetImage(img)
 			btn.SetAlwaysShowImage(true)
@@ -245,10 +240,19 @@ func flowBoxButton(entry desktopEntry) *gtk.Button {
 	button, _ := gtk.ButtonNew()
 	button.SetAlwaysShowImage(true)
 
-	img, err := getImageFromIcon(entry.Icon)
+	var pixbuf *gdk.Pixbuf
+	var img *gtk.Image
+	var err error
+	if entry.Icon != "" {
+		pixbuf, err = createPixbuf(entry.Icon, *iconSize)
+	} else {
+		pixbuf, err = createPixbuf("image-missing", *iconSize)
+	}
 	if err != nil {
 		log.Error(err)
+		pixbuf, _ = createPixbuf("unknown", *iconSize)
 	}
+	img, _ = gtk.ImageNewFromPixbuf(pixbuf)
 
 	button.SetImage(img)
 	button.SetImagePosition(gtk.POS_TOP)


### PR DESCRIPTION
Here is behavior with missing icons in the theme before this patch:
![image](https://user-images.githubusercontent.com/62964550/134338624-2969fcd4-9493-4c45-a6b7-44f8743b8044.png)

Here is behavior with this patch:
![image](https://user-images.githubusercontent.com/62964550/134338653-9bb5b7f6-c613-4faf-981b-bbd50fc2842b.png)
