### PR TITLE
create empty pinned file if not found on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ and `nwggrid`.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/nwg-drawer.svg)](https://repology.org/project/nwg-drawer/versions)
 
+To close the window w/o running a program, you may use `Esc` key, or right-click the window next to the icons.
+
 ## v0.2.x note
 
 1. Placing config files in the nwg-panel config directory was a mistake, sorry. The 0.2.0 version migrates them to `~/.config/nwg-drawer`.
-2. From now on you may run the program residently, which should speed it up. See "Running" below.
+2. From now on you may run the program residently, which should speed it up (but also occupy some resources!). See "Running" below.
 
 ## Installation
 
@@ -38,7 +40,7 @@ and `nwggrid`.
 Optional (recommended):
 
 - thunar
-- alacritty
+- foot
 
 You may use another file manager and terminal emulator (see command line arguments), but mentioned above have been
 confirmed to work well with the program. Also see **Files** below.

--- a/main.go
+++ b/main.go
@@ -251,6 +251,7 @@ func main() {
 	pinned, err = loadTextFile(pinnedFile)
 	if err != nil {
 		pinned = nil
+		savePinned()
 	}
 	log.Info(fmt.Sprintf("Found %v pinned items", len(pinned)))
 

--- a/main.go
+++ b/main.go
@@ -495,6 +495,7 @@ func main() {
 	glib.TimeoutAdd(uint(1), func() bool {
 		if showWindowTrigger && win != nil && !win.IsVisible() {
 			win.ShowAll()
+			fileSearchResultWrapper.Hide()
 			// focus 1st element
 			b := appFlowBox.GetChildAtIndex(0)
 			if b != nil {


### PR DESCRIPTION
This resolves the issue of pin/unpin action invisible if the first item has been pinned in resident mode. And also fixes some other minor issues.