### PR TITLE
check if fileSearchResultWrapper exists #45

### DIFF
--- a/main.go
+++ b/main.go
@@ -495,7 +495,9 @@ func main() {
 	glib.TimeoutAdd(uint(1), func() bool {
 		if showWindowTrigger && win != nil && !win.IsVisible() {
 			win.ShowAll()
-			fileSearchResultWrapper.Hide()
+			if fileSearchResultWrapper != nil {
+				fileSearchResultWrapper.Hide()
+			}
 			// focus 1st element
 			b := appFlowBox.GetChildAtIndex(0)
 			if b != nil {


### PR DESCRIPTION
This fixes regression introduced in `92095d5b971a50ee0b19e7d88f5af0f0e1df02a9`. Closes #45 