### PR TITLE
Fix high CPU load

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -41,7 +41,9 @@ func watchFiles() {
 						event.Op.String() == "RENAME") {
 					desktopTrigger = true
 				} else if event.Name == pinnedFile {
-					pinnedTrigger = true
+					// TODO: This can be used to propagate information about the changed file to the
+					//       GUI to avoid recreating everything
+					pinnedItemsChanged <- struct{}{}
 				}
 
 			case err := <-watcher.Errors:


### PR DESCRIPTION
This PR fixes #50 by using a channel instead of a boolean flag that is polled in a fixed interval.
Currently all updates done by the file watcher will only be applied before displaying the window, which wasn't the case before, but I think it is still sufficient for the current usecase.