### PR TITLE
Custom categories

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type category struct {
 	Name        string
 	DisplayName string
 	Icon        string
+	Apps        []string
 }
 
 var categories []category
@@ -65,19 +66,6 @@ type desktopEntry struct {
 	Terminal   bool
 	NoDisplay  bool
 }
-
-// slices below will hold DesktopID strings
-var (
-	listUtility            []string
-	listDevelopment        []string
-	listGame               []string
-	listGraphics           []string
-	listInternetAndNetwork []string
-	listOffice             []string
-	listAudioVideo         []string
-	listSystemTools        []string
-	listOther              []string
-)
 
 var desktopEntries []desktopEntry
 

--- a/main.go
+++ b/main.go
@@ -33,22 +33,23 @@ var (
 	exclusions      []string
 )
 
-var categoryNames = [...]string{
-	"utility",
-	"development",
-	"game",
-	"graphics",
-	"internet-and-network",
-	"office",
-	"audio-video",
-	"system-tools",
-	"other",
+var categoryMatches = map[string][]string{
+	"utility":              {"Utility"},
+	"development":          {"Development"},
+	"game":                 {"Game"},
+	"graphics":             {"Graphics"},
+	"internet-and-network": {"Network"},
+	"office":               {"Office", "Science", "Educations"},
+	"audio-video":          {"AudioVideo", "Audio", "Video"},
+	"system-tools":         {"Settings", "System", "DesktopSettings", "PackageManager"},
+	"other":                {},
 }
 
 type category struct {
 	Name        string
 	DisplayName string
 	Icon        string
+	Matches     []string
 	Apps        []string
 }
 

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func defaultStringIfBlank(s, fallback string) string {
 
 // Flags
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
+var userDefinedAppsDirectory = flag.String("dir", "", "where to search for applications")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")

--- a/main.go
+++ b/main.go
@@ -105,7 +105,6 @@ func defaultStringIfBlank(s, fallback string) string {
 
 // Flags
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
-var userDefinedAppsDirectory = flag.String("dir", "", "where to search for applications")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")

--- a/tools.go
+++ b/tools.go
@@ -308,6 +308,16 @@ func setUpCategories() {
 	path := filepath.Join(getDataHome(), "nwg-drawer/desktop-directories")
 	var other category
 
+	jsonFile, err := os.Open("/home/apoema/.config/nwg-drawer/categories.json")
+	if err == nil {
+		byteValue, _ := ioutil.ReadAll(jsonFile)
+
+		var usrCats []category
+		json.Unmarshal([]byte(byteValue), &usrCats)
+		categories = append(categories, usrCats[:]...)
+	}
+	defer jsonFile.Close()
+
 	for _, cName := range categoryNames {
 		fileName := fmt.Sprintf("%s.directory", cName)
 		lines, err := loadTextFile(filepath.Join(path, fileName))
@@ -399,53 +409,15 @@ func parseDesktopFiles(desktopFiles []string) string {
 }
 
 // freedesktop Main Categories list consists of 13 entries. Let's contract it to 8+1 ("Other").
-func assignToLists(desktopID, categories string) {
-	cats := strings.Split(categories, ";")
-	assigned := false
-	for _, cat := range cats {
-		if cat == "Utility" && !isIn(listUtility, desktopID) {
-			listUtility = append(listUtility, desktopID)
-			assigned = true
-			continue
+func assignToLists(desktopID, appCategories string) {
+	cats := strings.Split(appCategories, ";")
+	for i := 0; i < len(categories); i++ {
+		for _, appCat := range cats {
+			if appCat == categories[i].Name {
+				categories[i].Apps = append(categories[i].Apps, desktopID)
+				continue
+			}
 		}
-		if cat == "Development" && !isIn(listDevelopment, desktopID) {
-			listDevelopment = append(listDevelopment, desktopID)
-			assigned = true
-			continue
-		}
-		if cat == "Game" && !isIn(listGame, desktopID) {
-			listGame = append(listGame, desktopID)
-			assigned = true
-			continue
-		}
-		if cat == "Graphics" && !isIn(listGraphics, desktopID) {
-			listGraphics = append(listGraphics, desktopID)
-			assigned = true
-			continue
-		}
-		if cat == "Network" && !isIn(listInternetAndNetwork, desktopID) {
-			listInternetAndNetwork = append(listInternetAndNetwork, desktopID)
-			assigned = true
-			continue
-		}
-		if isIn([]string{"Office", "Science", "Education"}, cat) && !isIn(listOffice, desktopID) {
-			listOffice = append(listOffice, desktopID)
-			assigned = true
-			continue
-		}
-		if isIn([]string{"AudioVideo", "Audio", "Video"}, cat) && !isIn(listAudioVideo, desktopID) {
-			listAudioVideo = append(listAudioVideo, desktopID)
-			assigned = true
-			continue
-		}
-		if isIn([]string{"Settings", "System", "DesktopSettings", "PackageManager"}, cat) && !isIn(listSystemTools, desktopID) {
-			listSystemTools = append(listSystemTools, desktopID)
-			assigned = true
-			continue
-		}
-	}
-	if categories != "" && !assigned && !isIn(listOther, desktopID) {
-		listOther = append(listOther, desktopID)
 	}
 }
 

--- a/tools.go
+++ b/tools.go
@@ -224,32 +224,27 @@ func getAppDirs() []string {
 	var dirs []string
 	xdgDataDirs := ""
 
-	userApps := *userDefinedAppsDirectory
-	if userApps != "" {
-		dirs = append(dirs, userApps)
+	home := os.Getenv("HOME")
+	xdgDataHome := os.Getenv("XDG_DATA_HOME")
+	if os.Getenv("XDG_DATA_DIRS") != "" {
+		xdgDataDirs = os.Getenv("XDG_DATA_DIRS")
 	} else {
-		home := os.Getenv("HOME")
-		xdgDataHome := os.Getenv("XDG_DATA_HOME")
-		if os.Getenv("XDG_DATA_DIRS") != "" {
-			xdgDataDirs = os.Getenv("XDG_DATA_DIRS")
-		} else {
-			xdgDataDirs = "/usr/local/share/:/usr/share/"
-		}
-		if xdgDataHome != "" {
-			dirs = append(dirs, filepath.Join(xdgDataHome, "applications"))
-		} else if home != "" {
-			dirs = append(dirs, filepath.Join(home, ".local/share/applications"))
-		}
-		for _, d := range strings.Split(xdgDataDirs, ":") {
-			dirs = append(dirs, filepath.Join(d, "applications"))
-		}
-		flatpakDirs := []string{filepath.Join(home, ".local/share/flatpak/exports/share/applications"),
-			"/var/lib/flatpak/exports/share/applications"}
+		xdgDataDirs = "/usr/local/share/:/usr/share/"
+	}
+	if xdgDataHome != "" {
+		dirs = append(dirs, filepath.Join(xdgDataHome, "applications"))
+	} else if home != "" {
+		dirs = append(dirs, filepath.Join(home, ".local/share/applications"))
+	}
+	for _, d := range strings.Split(xdgDataDirs, ":") {
+		dirs = append(dirs, filepath.Join(d, "applications"))
+	}
+	flatpakDirs := []string{filepath.Join(home, ".local/share/flatpak/exports/share/applications"),
+		"/var/lib/flatpak/exports/share/applications"}
 
-		for _, d := range flatpakDirs {
-			if pathExists(d) && !isIn(dirs, d) {
-				dirs = append(dirs, d)
-			}
+	for _, d := range flatpakDirs {
+		if pathExists(d) && !isIn(dirs, d) {
+			dirs = append(dirs, d)
 		}
 	}
 	var confirmedDirs []string

--- a/tools.go
+++ b/tools.go
@@ -224,27 +224,32 @@ func getAppDirs() []string {
 	var dirs []string
 	xdgDataDirs := ""
 
-	home := os.Getenv("HOME")
-	xdgDataHome := os.Getenv("XDG_DATA_HOME")
-	if os.Getenv("XDG_DATA_DIRS") != "" {
-		xdgDataDirs = os.Getenv("XDG_DATA_DIRS")
+	userApps := *userDefinedAppsDirectory
+	if userApps != "" {
+		dirs = append(dirs, userApps)
 	} else {
-		xdgDataDirs = "/usr/local/share/:/usr/share/"
-	}
-	if xdgDataHome != "" {
-		dirs = append(dirs, filepath.Join(xdgDataHome, "applications"))
-	} else if home != "" {
-		dirs = append(dirs, filepath.Join(home, ".local/share/applications"))
-	}
-	for _, d := range strings.Split(xdgDataDirs, ":") {
-		dirs = append(dirs, filepath.Join(d, "applications"))
-	}
-	flatpakDirs := []string{filepath.Join(home, ".local/share/flatpak/exports/share/applications"),
-		"/var/lib/flatpak/exports/share/applications"}
+		home := os.Getenv("HOME")
+		xdgDataHome := os.Getenv("XDG_DATA_HOME")
+		if os.Getenv("XDG_DATA_DIRS") != "" {
+			xdgDataDirs = os.Getenv("XDG_DATA_DIRS")
+		} else {
+			xdgDataDirs = "/usr/local/share/:/usr/share/"
+		}
+		if xdgDataHome != "" {
+			dirs = append(dirs, filepath.Join(xdgDataHome, "applications"))
+		} else if home != "" {
+			dirs = append(dirs, filepath.Join(home, ".local/share/applications"))
+		}
+		for _, d := range strings.Split(xdgDataDirs, ":") {
+			dirs = append(dirs, filepath.Join(d, "applications"))
+		}
+		flatpakDirs := []string{filepath.Join(home, ".local/share/flatpak/exports/share/applications"),
+			"/var/lib/flatpak/exports/share/applications"}
 
-	for _, d := range flatpakDirs {
-		if pathExists(d) && !isIn(dirs, d) {
-			dirs = append(dirs, d)
+		for _, d := range flatpakDirs {
+			if pathExists(d) && !isIn(dirs, d) {
+				dirs = append(dirs, d)
+			}
 		}
 	}
 	var confirmedDirs []string

--- a/tools.go
+++ b/tools.go
@@ -318,12 +318,13 @@ func setUpCategories() {
 	}
 	defer jsonFile.Close()
 
-	for _, cName := range categoryNames {
+	for cName, cMatches := range categoryMatches {
 		fileName := fmt.Sprintf("%s.directory", cName)
 		lines, err := loadTextFile(filepath.Join(path, fileName))
 		if err == nil {
 			var cat category
 			cat.Name = cName
+			cat.Matches = cMatches
 
 			name := ""
 			nameLoc := ""
@@ -367,6 +368,7 @@ func setUpCategories() {
 			}
 		}
 	}
+
 	sort.Slice(categories, func(i, j int) bool {
 		return categories[i].DisplayName < categories[j].DisplayName
 	})
@@ -411,11 +413,15 @@ func parseDesktopFiles(desktopFiles []string) string {
 // freedesktop Main Categories list consists of 13 entries. Let's contract it to 8+1 ("Other").
 func assignToLists(desktopID, appCategories string) {
 	cats := strings.Split(appCategories, ";")
+	assigned := false
 	for i := 0; i < len(categories); i++ {
 		for _, appCat := range cats {
-			if appCat == categories[i].Name {
+			if isIn(categories[i].Matches, appCat) {
 				categories[i].Apps = append(categories[i].Apps, desktopID)
+				assigned = true
 				continue
+			} else if i == len(categories)-1 && !assigned {
+				categories[i].Apps = append(categories[i].Apps, desktopID)
 			}
 		}
 	}

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -95,18 +95,6 @@ func setUpPinnedFlowBox() *gtk.FlowBox {
 }
 
 func setUpCategoriesButtonBox() *gtk.EventBox {
-	lists := map[string][]string{
-		"utility":              listUtility,
-		"development":          listDevelopment,
-		"game":                 listGame,
-		"graphics":             listGraphics,
-		"internet-and-network": listInternetAndNetwork,
-		"office":               listOffice,
-		"audio-video":          listAudioVideo,
-		"system-tools":         listSystemTools,
-		"other":                listOther,
-	}
-
 	eventBox, _ := gtk.EventBoxNew()
 
 	hBox, _ := gtk.BoxNew(gtk.ORIENTATION_HORIZONTAL, 0)
@@ -124,19 +112,19 @@ func setUpCategoriesButtonBox() *gtk.EventBox {
 	hBox.PackStart(button, false, false, 0)
 
 	for _, cat := range categories {
-		if isSupposedToShowUp(cat.Name) {
+		if isSupposedToShowUp(cat) {
 			button, _ = gtk.ButtonNewFromIconName(cat.Icon, gtk.ICON_SIZE_MENU)
 			button.SetProperty("name", "category-button")
 			catButtons = append(catButtons, button)
 			button.SetLabel(cat.DisplayName)
 			button.SetAlwaysShowImage(true)
 			hBox.PackStart(button, false, false, 0)
-			name := cat.Name
+			list := cat.Apps
 			b := *button
 			button.Connect("clicked", func(item *gtk.Button) {
 				searchEntry.SetText("")
 				// !!! since gotk3 FlowBox type does not implement set_filter_func, we need to rebuild appFlowBox
-				appFlowBox = setUpAppsFlowBox(lists[name], "")
+				appFlowBox = setUpAppsFlowBox(list, "")
 				for _, btn := range catButtons {
 					btn.SetImagePosition(gtk.POS_LEFT)
 				}
@@ -152,18 +140,8 @@ func setUpCategoriesButtonBox() *gtk.EventBox {
 	return eventBox
 }
 
-func isSupposedToShowUp(catName string) bool {
-	result := catName == "utility" && notEmpty(listUtility) ||
-		catName == "development" && notEmpty(listDevelopment) ||
-		catName == "game" && notEmpty(listGame) ||
-		catName == "graphics" && notEmpty(listGraphics) ||
-		catName == "internet-and-network" && notEmpty(listInternetAndNetwork) ||
-		catName == "office" && notEmpty(listOffice) ||
-		catName == "audio-video" && notEmpty(listAudioVideo) ||
-		catName == "system-tools" && notEmpty(listSystemTools) ||
-		catName == "other" && notEmpty(listOther)
-
-	return result
+func isSupposedToShowUp(cat category) bool {
+	return notEmpty(cat.Apps)
 }
 
 func notEmpty(listCategory []string) bool {


### PR DESCRIPTION
# Adding Custom Categories

The changes in this pull request add the ability for the dynamic creating of categories, allow of user defined categories to be user by `nwg-drawer`

## Spiel

I want to spend some time convincing you that this changes are not only something necessary to cover my "very specific use case", I also think that the changes make the code simpler and easier to maintain. I have deleted more lines than I have added.

The current category code is using a case by case basis which imply that any modification or addition of categories means the developer have to modify the code in multiple sections, increasing work load and margin for error. My changes try to parametrize the process making it more dynamic and easier to deal with (in my opinion).

## Changes

Brief explanation of the modification in each file.

### main.go

The main change here is the exclusion of the `listCategory*` global variables, this is replaced by a new property in the category struct: `Apps`. That is what was previously saved in `listUtility` is now saved in `categories[0].Apps`.

The second change is the modification of the global variable `categoryNames` to `categoryMatches`. In the current code multiple entries' category are grouped in the same umbrella category by using a list of hardcoded matches. I moved the parametrization from the `assignToList` function to `categoryMatches`.

### tools.go

I will start on the end of the File. `assignToList` function was rewritten and now it uses two for loops to go through all the possible categories and assigning the desktop entries to `cat.App` if the categories on the entry matches `cat.Matches`. (*I just noticed I am not checking if the entry is not already on the category, have to fix that*).

The other change is the introduction of the JSON configuration file. The program looks for `$XDG_CONFIG_HOME/nwd-drawer/categories.json` and adds any categories defined there, an example of a configuration file is:

```
[
  {
    "Name": "Retroarch",
    "DisplayName": "Retroarch",
    "Icon": "applications-games",
    "Matches": ["Retroarch"],
  }
]
```

Which creates a Category named Retrorarch.

To be honest I dislike the fact that this method of creating categories is different from the current one. But I think that using one file to create all user defined categories is more friendly and have to user define multiple `*.directory` file, also JSON is more well known and widely used which also contributes to user friendliness. I tried transforming the current `*.directory` files to JSON file(s) but that proved hard to do. I am looking forward for you opinion on the subject. 

### uicomponents.go

There is not much to talk about here, all references to `listCategory*` are changed to `cat.Apps`. 

Sorry to give you trouble. Take your time going though this. I have tested this and it looks to be working nicely. I will keep using it though to see if I notice any hidden problems. 