### PR TITLE
Support for changing GTK theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Usage of nwg-drawer:
     	File Search result COLumns (default 2)
   -fslen int
     	File Search name LENgth Limit (default 80)
+  -g string
+    	GTK theme name, eg. "Adwaita-dark"
   -is int
     	Icon Size (default 64)
   -lang string

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")
+var gtkTheme = flag.String("g", "", "GTK theme name")
 var iconSize = flag.Int("is", 64, "Icon Size")
 var marginTop = flag.Int("mt", 0, "Margin Top")
 var marginLeft = flag.Int("ml", 0, "Margin Left")
@@ -301,6 +302,14 @@ func main() {
 
 	// USER INTERFACE
 	gtk.Init(nil)
+
+	if *gtkTheme != "" {
+		settings, _ := gtk.SettingsGetDefault()
+		err = settings.SetProperty("gtk-theme-name", *gtkTheme)
+		if err != nil {
+			log.Error("Unable to set theme:", err)
+		}
+	}
 
 	cssProvider, _ := gtk.CssProviderNew()
 


### PR DESCRIPTION
This pull request adds an argument to change the GTK theme. Unlike changing the theme with environment variables or gsettings, the change doesn't effect other applications.
I added the same functionality to nwg-launchers (nwg-piotr/nwg-launchers#200) but now I use sway with nwg-drawer and would like to see it merged here.
It's my first time working in go, I hope the code is ok. I tested this on sway for 4 days and had no issues.