### PR TITLE
Fix #69

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,7 +243,10 @@ func main() {
 
 	// Copy default style sheet if not found
 	if !pathExists(filepath.Join(configDirectory, "drawer.css")) {
-		copyFile(filepath.Join(getDataHome(), "nwg-drawer/drawer.css"), filepath.Join(configDirectory, "drawer.css"))
+		err := copyFile("/usr/share/nwg-drawer/drawer.css", filepath.Join(configDirectory, "drawer.css"))
+		if err != nil {
+			log.Errorf("Failed copying 'drawer.css' file: %s", err)
+		}
 	}
 
 	cacheDirectory := cacheDir()
@@ -312,7 +315,11 @@ func main() {
 			log.Infof("User demanded theme: %s", *gtkTheme)
 		}
 	} else {
-		settings.SetProperty("gtk-application-prefer-dark-theme", true)
+		err := settings.SetProperty("gtk-application-prefer-dark-theme", true)
+		if err != nil {
+			log.Error("Error setting 'gtk-application-prefer-dark-theme' property")
+			return
+		}
 		log.Info("Preferring dark theme variants")
 	}
 

--- a/tools.go
+++ b/tools.go
@@ -196,12 +196,22 @@ func copyFile(src, dst string) error {
 	if srcfd, err = os.Open(src); err != nil {
 		return err
 	}
-	defer srcfd.Close()
+	defer func(srcfd *os.File) {
+		err := srcfd.Close()
+		if err != nil {
+			log.Errorf("Error closing file: %v", srcfd)
+		}
+	}(srcfd)
 
 	if dstfd, err = os.Create(dst); err != nil {
 		return err
 	}
-	defer dstfd.Close()
+	defer func(dstfd *os.File) {
+		err := dstfd.Close()
+		if err != nil {
+			log.Errorf("Error closing file: %v", dstfd)
+		}
+	}(dstfd)
 
 	if _, err = io.Copy(dstfd, srcfd); err != nil {
 		return err
@@ -253,7 +263,12 @@ func loadPreferredApps(path string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer jsonFile.Close()
+	defer func(jsonFile *os.File) {
+		err := jsonFile.Close()
+		if err != nil {
+			log.Errorf("Error closing file: %v", jsonFile)
+		}
+	}(jsonFile)
 
 	byteValue, _ := io.ReadAll(jsonFile)
 
@@ -511,7 +526,12 @@ func savePinned() {
 		log.Fatal(err)
 	}
 
-	defer f.Close()
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			log.Errorf("Error closing file: %v", f)
+		}
+	}(f)
 
 	for _, line := range pinned {
 		if line != "" {

--- a/tools.go
+++ b/tools.go
@@ -213,13 +213,6 @@ func copyFile(src, dst string) error {
 	return os.Chmod(dst, srcinfo.Mode())
 }
 
-func getDataHome() string {
-	if os.Getenv("XDG_DATA_HOME") != "" {
-		return os.Getenv("XDG_DATA_HOME")
-	}
-	return "/usr/share/"
-}
-
 func getAppDirs() []string {
 	var dirs []string
 	xdgDataDirs := ""
@@ -300,16 +293,13 @@ func listDesktopFiles() []string {
 }
 
 func setUpCategories() {
-	p := filepath.Join(getDataHome(), "nwg-drawer/desktop-directories")
-	log.Debugf("Desktop dirs location: %s", p)
 	var other category
 
 	for _, cName := range categoryNames {
 		fileName := fmt.Sprintf("%s.directory", cName)
-		fp := filepath.Join(p, fileName)
+		fp := filepath.Join("/usr/share/nwg-drawer/desktop-directories", fileName)
 		lines, err := loadTextFile(fp)
 		if err == nil {
-			log.Debugf("Opened file '%s'", fp)
 			var cat category
 			cat.Name = cName
 

--- a/tools.go
+++ b/tools.go
@@ -273,7 +273,7 @@ func loadPreferredApps(path string) (map[string]interface{}, error) {
 	byteValue, _ := io.ReadAll(jsonFile)
 
 	var result map[string]interface{}
-	err = json.Unmarshal([]byte(byteValue), &result)
+	err = json.Unmarshal(byteValue, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/tools.go
+++ b/tools.go
@@ -300,13 +300,16 @@ func listDesktopFiles() []string {
 }
 
 func setUpCategories() {
-	path := filepath.Join(getDataHome(), "nwg-drawer/desktop-directories")
+	p := filepath.Join(getDataHome(), "nwg-drawer/desktop-directories")
+	log.Debugf("Desktop dirs location: %s", p)
 	var other category
 
 	for _, cName := range categoryNames {
 		fileName := fmt.Sprintf("%s.directory", cName)
-		lines, err := loadTextFile(filepath.Join(path, fileName))
+		fp := filepath.Join(p, fileName)
+		lines, err := loadTextFile(fp)
 		if err == nil {
+			log.Debugf("Opened file '%s'", fp)
 			var cat category
 			cat.Name = cName
 
@@ -350,6 +353,8 @@ func setUpCategories() {
 			} else {
 				other = cat
 			}
+		} else {
+			log.Errorf("Couldn't open %s", fp)
 		}
 	}
 	sort.Slice(categories, func(i, j int) bool {

--- a/tools.go
+++ b/tools.go
@@ -538,7 +538,7 @@ func savePinned() {
 			_, err := f.WriteString(line + "\n")
 
 			if err != nil {
-				log.Errorf("Error saving pinned", err)
+				log.Error("Error saving pinned", err)
 			}
 		}
 	}

--- a/tools.go
+++ b/tools.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -143,7 +142,7 @@ func tempDir() string {
 }
 
 func readTextFile(path string) (string, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
@@ -256,10 +255,13 @@ func loadPreferredApps(path string) (map[string]interface{}, error) {
 	}
 	defer jsonFile.Close()
 
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 
 	var result map[string]interface{}
-	json.Unmarshal([]byte(byteValue), &result)
+	err = json.Unmarshal([]byte(byteValue), &result)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(result) == 0 {
 		return nil, errors.New("json invalid or empty")
@@ -268,8 +270,8 @@ func loadPreferredApps(path string) (map[string]interface{}, error) {
 	return result, nil
 }
 
-func listFiles(dir string) ([]fs.FileInfo, error) {
-	files, err := ioutil.ReadDir(dir)
+func listFiles(dir string) ([]fs.DirEntry, error) {
+	files, err := os.ReadDir(dir)
 	if err == nil {
 		return files, nil
 	}
@@ -458,7 +460,7 @@ func pathExists(name string) bool {
 }
 
 func loadTextFile(path string) ([]string, error) {
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- fixed path to own data dir; closes #69;
- minor fixes: replaced types deprecated in go 1.19; added some error handling; removed redundant type conversion.