### PR TITLE
Add keyboard mode flag to support both: "on-demand" & "exclusive" GTK layer-shell modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Usage of nwg-drawer:
     	GTK theme name, eg. "Adwaita-dark"
   -is int
     	Icon Size (default 64)
-  -k string
-    	Set GTK layer shell keyboard interactivity: 'exclusive' or 'on-demand' (or: 'e', 'o') (default "exclusive")
+  -k
+    	Set GTK layer shell keyboard interactivity to "on-demand" mode (default "exclusive")
   -lang string
     	force lang, e.g. "en", "pl"
   -nocats

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Usage of nwg-drawer:
     	GTK theme name, eg. "Adwaita-dark"
   -is int
     	Icon Size (default 64)
+  -k string
+    	Set GTK layer shell keyboard interactivity: 'exclusive' or 'on-demand' (or: 'e', 'o') (default "exclusive")
   -lang string
     	force lang, e.g. "en", "pl"
   -nocats

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func defaultStringIfBlank(s, fallback string) string {
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
-var keyboard = flag.String("k",        "exclusive", "Set GTK layer shell keyboard interactivity: 'none', 'exclusive' or 'on-demand' (or 'n', 'e' or 'o')")
+var keyboard = flag.String("k",        "exclusive", "Set GTK layer shell keyboard interactivity: 'exclusive' or 'on-demand' (or: 'e', 'o')")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")
 var gtkTheme = flag.String("g", "", "GTK theme name")
 var gtkIconTheme = flag.String("i", "", "GTK icon theme name")
@@ -393,9 +393,6 @@ func main() {
 		} else if (*keyboard)[0] == 'o' {
 			log.Info("Setting GTK layer shell keyboard mode to: on-demand")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND)
-		} else if (*keyboard)[0] == 'n' {
-			log.Info("Setting GTK layer shell keyboard mode to: none")
-			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_NONE)
 		} else {
 			log.Warnf("Invalid option passed to --keyboard: %s)", *keyboard)
 			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")

--- a/main.go
+++ b/main.go
@@ -388,7 +388,7 @@ func main() {
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_BOTTOM, *marginBottom)
 
 		if (*keyboard) == "" {
-			log.Warnf("Empty string passed to --keyboard: %s)", *keyboard)
+			log.Warnf("Empty string passed to -k: %s)", *keyboard)
 			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
 		} else if (*keyboard)[0] == 'e' {
@@ -398,7 +398,7 @@ func main() {
 			log.Info("Setting GTK layer shell keyboard mode to: on-demand")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND)
 		} else {
-			log.Warnf("Invalid option passed to --keyboard: %s)", *keyboard)
+			log.Warnf("Invalid option passed to -k: %s)", *keyboard)
 			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
 		}

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ func defaultStringIfBlank(s, fallback string) string {
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
+var keyboard = flag.String("k",        "exclusive", "Set GTK layer shell keyboard interactivity: 'none', 'exclusive' or 'on-demand' (or 'n', 'e' or 'o')")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")
 var gtkTheme = flag.String("g", "", "GTK theme name")
 var gtkIconTheme = flag.String("i", "", "GTK icon theme name")
@@ -386,7 +387,21 @@ func main() {
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_RIGHT, *marginRight)
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_BOTTOM, *marginBottom)
 
-		layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
+		if (*keyboard)[0] == 'e' {
+			log.Info("Setting GTK layer shell keyboard mode to: exclusive")
+			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
+		} else if (*keyboard)[0] == 'o' {
+			log.Info("Setting GTK layer shell keyboard mode to: on-demand")
+			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND)
+		} else if (*keyboard)[0] == 'n' {
+			log.Info("Setting GTK layer shell keyboard mode to: none")
+			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_NONE)
+		} else {
+			log.Warnf("Invalid option passed to --keyboard: %s)", *keyboard)
+			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
+			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
+		}
+
 	}
 
 	win.Connect("destroy", func() {

--- a/main.go
+++ b/main.go
@@ -387,7 +387,11 @@ func main() {
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_RIGHT, *marginRight)
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_BOTTOM, *marginBottom)
 
-		if (*keyboard)[0] == 'e' {
+		if (*keyboard) == "" {
+			log.Warnf("Empty string passed to --keyboard: %s)", *keyboard)
+			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
+			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
+		} else if (*keyboard)[0] == 'e' {
 			log.Info("Setting GTK layer shell keyboard mode to: exclusive")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
 		} else if (*keyboard)[0] == 'o' {

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func defaultStringIfBlank(s, fallback string) string {
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
 var displayVersion = flag.Bool("v", false, "display Version information")
-var keyboard = flag.String("k",        "exclusive", "Set GTK layer shell keyboard interactivity: 'exclusive' or 'on-demand' (or: 'e', 'o')")
+var keyboard = flag.Bool("k", false, "Set GTK layer shell keyboard interactivity to 'on-demand' mode")
 var overlay = flag.Bool("ovl", false, "use OVerLay layer")
 var gtkTheme = flag.String("g", "", "GTK theme name")
 var gtkIconTheme = flag.String("i", "", "GTK icon theme name")
@@ -387,19 +387,11 @@ func main() {
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_RIGHT, *marginRight)
 		layershell.SetMargin(win, layershell.LAYER_SHELL_EDGE_BOTTOM, *marginBottom)
 
-		if (*keyboard) == "" {
-			log.Warnf("Empty string passed to -k: %s)", *keyboard)
-			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
-			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
-		} else if (*keyboard)[0] == 'e' {
-			log.Info("Setting GTK layer shell keyboard mode to: exclusive")
-			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
-		} else if (*keyboard)[0] == 'o' {
+		if *keyboard {
 			log.Info("Setting GTK layer shell keyboard mode to: on-demand")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND)
 		} else {
-			log.Warnf("Invalid option passed to -k: %s)", *keyboard)
-			log.Warn("Setting GTK layer shell keyboard mode to default: exclusive")
+			log.Info("Setting GTK layer shell keyboard mode to default: exclusive")
 			layershell.SetKeyboardMode(win, layershell.LAYER_SHELL_KEYBOARD_MODE_EXCLUSIVE)
 		}
 


### PR DESCRIPTION
# Change

- Add a `-k` flag to set the GTK layer shell keyboard focus mode
  - Modes supported are:
    - `exclusive` / `e` (Default)
    - `on-demand` / `o`
  - **Note:** `none` mode does not seem to make sense for this app, because it disables keyboard input completely.
# Rationale / Background:

`gtk-layer-shell`, and Wayland now supports [an "On Demand" mode][1] via `zwlr_layer_surface_v1::keyboard_interactivity v4` for keyboard focus.  The [demo app][2] also supports this mode and works well to demonstrate the new `zwlr_layer_surface_v1::keyboard_interactivity v4` wayland protocol for the on-demand keyboard focus mode.

**Note** that for this to behave differently, it requires a newer version of `sway` than is currently released on most Linux distros, but it will not break anything given the backwards-compatible behavior being `exclusive` by default. (e.g. without this change: swaywm/sway@913a7679 / swaywm/sway#7587 ... and with `on-demand` mode set, it still behaves as if `exclusive` mode was set)

The following PRs have made it into `wl-protocols`, `wlroots`, & `gtk-layer-shell`:

- swaywm/wlr-protocols#100
- swaywm/wlroots#2555
- wmww/gtk-layer-shell#105

<sub>**Note:** there is also one for wayfire: WayfireWM/wayfire#962</sub>

Testing the `gtk-layer-shell` demo program on Sway `1.8.1` behaves the same. For example: When setting the "On Demand" keyboard mode (`--keyboard o`) and either "Top" or "Overlay" layers (`--layer t` or `--layer o`).

When on these layers, it's impossible to get keyboard focus off of the demo program window without first setting keyboard setting back to "None".  While not ideal from a UI/UX perspective, nor from an app developer perspective, it doesn't hurt to have this option in client programs to enable the feature when `sway` or other window managers adopt the `zwlr_layer_surface_v1::keyboard_interactivity` `v4` protocol.  

More information can be found in: swaywm/sway#7499.


[1]: https://github.com/search?q=repo%3Adlasky/gotk3-layershell%20LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND&type=code
[2]: https://github.com/wmww/gtk-layer-shell/blob/e22c43838a4931a229db95f3011fb195195a5785/examples/demo/gtk-layer-demo.c#L92C25-L92C108