### PR TITLE
Add the `swaymsg` flag to launch a program with `swaymsg exec` and prevent potential involuntary closing with Jetbrains IDEs

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,6 +114,16 @@ func defaultStringIfBlank(s, fallback string) string {
 	return s
 }
 
+func defaultBoolIfBlank(s string, fallback bool) bool {
+	s = strings.TrimSpace(s)
+	// os.Getenv("TERM") returns "linux" instead of empty string, if program has been started
+	// from a key binding defined in the config file. See #23.
+	if s != "sway" {
+		return fallback
+	}
+	return true
+}
+
 // Flags
 var cssFileName = flag.String("s", "drawer.css", "Styling: css file name")
 var targetOutput = flag.String("o", "", "name of the Output to display the drawer on (sway only)")
@@ -134,6 +144,7 @@ var itemSpacing = flag.Uint("spacing", 20, "icon spacing")
 var lang = flag.String("lang", "", "force lang, e.g. \"en\", \"pl\"")
 var fileManager = flag.String("fm", "thunar", "File Manager")
 var term = flag.String("term", defaultStringIfBlank(os.Getenv("TERM"), "foot"), "Terminal emulator")
+var swaymsg = flag.Bool("swaymsg", defaultBoolIfBlank(os.Getenv("XDG_CURRENT_DESKTOP"), false), "Use swaymsg (sway only)")
 var nameLimit = flag.Int("fslen", 80, "File Search name LENgth Limit")
 var noCats = flag.Bool("nocats", false, "Disable filtering by category")
 var noFS = flag.Bool("nofs", false, "Disable file search")

--- a/tools.go
+++ b/tools.go
@@ -592,15 +592,20 @@ func launch(command string, terminal bool) {
 
 	cmd := exec.Command(elements[cmdIdx], elements[1+cmdIdx:]...)
 
+	var prefixCommand string
+	var args []string
 	if terminal {
-		var args []string
+		prefixCommand = *term
 		if *term != "foot" {
 			args = []string{"-e", elements[cmdIdx]}
 		} else {
 			args = []string{elements[cmdIdx]}
 		}
-
-		cmd = exec.Command(*term, args...)
+		cmd = exec.Command(prefixCommand, args...)
+	} else if *swaymsg {
+		prefixCommand = "swaymsg"
+		args = []string{"exec", elements[cmdIdx]}
+		cmd = exec.Command(prefixCommand, args...)
 	}
 
 	// set env variables


### PR DESCRIPTION
# Description

This pull request adds the `swaymsg` flag to the `nwg-drawer` command to launch a program with the `swaymsg exec` command. This prevents potential unintentional closure with Jetbrains IDEs.

# Advantages

- Prevents unintentional closing of programs launched with no swaymsg exec and no terminal
- Improves stability of Jetbrains IDEs

# Instructions

To use this new feature, simply add the `-swaymsg` flag to the `nwg-drawer` command, or set the `XDG_CURRENT_DESKTOP` environment variable to "sway".

## Example

### Before

    rubymine # without -term, -swaymsg and without XDG_CURRENT_DESKTOP=sway

### After

    swaymsg exec firefox # with -swaymsg or with XDG_CURRENT_DESKTOP=sway