### PR TITLE
Change command execution logic and use `/usr/bin/env` command

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -548,6 +548,14 @@ func savePinned() {
 }
 
 func launch(command string, terminal bool) {
+	// trim % and everything afterwards
+	if strings.Contains(command, "%") {
+		cutAt := strings.Index(command, "%")
+		if cutAt != -1 {
+			command = command[:cutAt-1]
+		}
+	}
+
 	themeToPrepend := ""
 	// add "GTK_THEME=<default_gtk_theme>" environment variable
 	if *forceTheme {

--- a/tools.go
+++ b/tools.go
@@ -557,55 +557,22 @@ func launch(command string, terminal bool) {
 			themeToPrepend = th.(string)
 		}
 	}
-	// trim % and everything afterwards
-	if strings.Contains(command, "%") {
-		cutAt := strings.Index(command, "%")
-		if cutAt != -1 {
-			command = command[:cutAt-1]
-		}
-	}
-
-	elements := strings.Split(command, " ")
-
-	envVarsNum := 0
-	if strings.Contains(elements[0], "=") {
-		for _, element := range elements {
-			if strings.Contains(element, "=") {
-				envVarsNum++
-			} else {
-				break
-			}
-		}
-	}
-
-	// find prepended env variables, if any
-	var envVars []string
 
 	if themeToPrepend != "" {
-		envVars = append(envVars, fmt.Sprintf("GTK_THEME=%s", themeToPrepend))
+		command = fmt.Sprintf("GTK_THEME=%q %s", themeToPrepend, command)
 	}
 
-	cmdIdx := envVarsNum
-	firstArgIdx := envVarsNum + 1
+	var elements = []string{"/usr/bin/env", "-S", command}
 
-	if envVarsNum > 0 {
-		for idx, item := range elements {
-			if envVarsNum > idx && strings.Contains(item, "=") {
-				envVars = append(envVars, item)
-			}
-		}
-	}
+	cmd := exec.Command(elements[0], elements[1:]...)
 
-	cmd := exec.Command(elements[cmdIdx], elements[firstArgIdx:]...)
-
-	var prefixCommand string
-	var args []string
 	if terminal {
-		prefixCommand = *term
-		if *term != "foot" {
-			args = []string{"-e", strings.Join(elements, " ")}
+		var prefixCommand = *term
+		var args []string
+		if prefixCommand != "foot" {
+			args = []string{"-e", command}
 		} else {
-			args = elements[cmdIdx:]
+			args = elements
 		}
 		cmd = exec.Command(prefixCommand, args...)
 	} else if *wm == "sway" {
@@ -614,13 +581,7 @@ func launch(command string, terminal bool) {
 		cmd = exec.Command("hyprctl", "dispatch", "exec", strings.Join(elements, " "))
 	}
 
-	// set env variables
-	if len(envVars) > 0 {
-		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, envVars...)
-	}
-
-	msg := fmt.Sprintf("env vars: %s; command: '%s'; args: %s\n", envVars, cmd.Args[0], cmd.Args[1:])
+	msg := fmt.Sprintf("command: %q; args: %q\n", cmd.Args[0], cmd.Args[1:])
 	log.Info(msg)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
# Description

@apognu told me in mp that the approach used was perhaps too complex for nwg-drawer's needs and advised me to use the `env` command.

According to him, nwg-drawer should never try to parse a command line to separate the envvars, from the command, from the arguments, it's actually super complicated (yes indeed :smile:). `env` is on all UNIX, this command allows you to launch a command with an environment and arguments, and it takes care of the parsing as it should.

So in the case of nwg-drawer, instead of doing your own parsing, you could simply run :

- ["env", "-S", <cmd>]
- ["swaymsg", "exec", "env", "-S", <cmd>]
- ["hyprctl", "dispatch", "exec", "env", "-S", <cmd>]

So I've simplified everything, taking his advice into account, and my tests are correct.