### PR TITLE
Make the description line at the bottom of the drawer themable

### DIFF
--- a/main.go
+++ b/main.go
@@ -542,8 +542,10 @@ func main() {
 	}
 
 	statusLineWrapper, _ := gtk.BoxNew(gtk.ORIENTATION_HORIZONTAL, 0)
+	statusLineWrapper.SetProperty("name", "status-line-wrapper")
 	outerVBox.PackStart(statusLineWrapper, false, false, 10)
 	statusLabel, _ = gtk.LabelNew(status)
+	statusLabel.SetProperty("name", "status-label")
 	statusLineWrapper.PackStart(statusLabel, true, false, 0)
 
 	win.ShowAll()


### PR DESCRIPTION
Adds the ability to theme the description / status line by using the CSS selectors #status-line-wrapper and #status-label.