### PR TITLE
remove `XDG_CURRENT_DESKTOP` as default `-wm` value; allow capitalized `Hyprland`

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,9 +123,9 @@ func defaultStringIfBlank(s, fallback string) string {
 }
 
 func validateWm() {
-	if !(*wm == "sway" || *wm == "hyprland") && *wm != "" {
+	if !(*wm == "sway" || *wm == "hyprland" || *wm == "Hyprland") && *wm != "" {
 		*wm = ""
-		log.Warn("-wm argument supports only sway or hyprland string.")
+		log.Warn("-wm argument supports only 'sway' or 'hyprland' string.")
 	}
 }
 
@@ -149,7 +149,7 @@ var itemSpacing = flag.Uint("spacing", 20, "icon spacing")
 var lang = flag.String("lang", "", "force lang, e.g. \"en\", \"pl\"")
 var fileManager = flag.String("fm", "thunar", "File Manager")
 var term = flag.String("term", defaultTermIfBlank(os.Getenv("TERM"), "foot"), "Terminal emulator")
-var wm = flag.String("wm", defaultStringIfBlank(os.Getenv("XDG_CURRENT_DESKTOP"), ""), "Use swaymsg (with 'sway' argument) or hyprctl (with 'hyprland')")
+var wm = flag.String("wm", "", "Use swaymsg (with 'sway' argument) or hyprctl (with 'hyprland')")
 var nameLimit = flag.Int("fslen", 80, "File Search name LENgth Limit")
 var noCats = flag.Bool("nocats", false, "Disable filtering by category")
 var noFS = flag.Bool("nofs", false, "Disable file search")

--- a/tools.go
+++ b/tools.go
@@ -585,7 +585,7 @@ func launch(command string, terminal bool) {
 		cmd = exec.Command(prefixCommand, args...)
 	} else if *wm == "sway" {
 		cmd = exec.Command("swaymsg", "exec", strings.Join(elements, " "))
-	} else if *wm == "hyprland" {
+	} else if *wm == "hyprland" || *wm == "Hyprland" {
 		cmd = exec.Command("hyprctl", "dispatch", "exec", strings.Join(elements, " "))
 	}
 


### PR DESCRIPTION
@gouvinb: Setting $XDG_CURRENT_DESKTOP as the default `-wm` argument value basically makes the argument useless. This way on sway and Hyprland we always have auto-detection, and we always launch apps via the compositor. I want users to have a choice, and give up on this feature if they want, by just not using the `-wm` argument.

BTW: yesterday I had an user with such an issue: nwg-drawer would always refuse to launch apps, and the coommand looked like this (on Hyprland):

```text
INFO[0002] command: "swaymsg"; args: ["exec" "/usr/bin/env -S <command>"]
```

It turned out that, for some mysterious reason, he set `env = XDG_CURRENT_DESKTOP, sway` in the Hyprland config file. Of course it was his fault, but I realized, that any improper `$XDG_CURRENT_DESKTOP` value will get us into trouble.