### PR TITLE
Add a close button for touch users.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nwg-drawer
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+.go/

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ nwg-drawer
 
 # Dependency directories (remove the comment below to include it)
 vendor/
-.go/

--- a/main.go
+++ b/main.go
@@ -185,7 +185,7 @@ var pbSleep = flag.String("pbsleep", "", "command for the sleep power bar icon")
 var pbSize = flag.Int("pbsize", 64, "power bar icon size (only works w/ built-in icons)")
 var pbUseIconTheme = flag.Bool("pbuseicontheme", false, "use icon theme instead of built-in icons in power bar")
 var showCloseButton = flag.Bool("closebtn", false, "Show the close button")
-var closeButtonLeft = flag.Bool("closebtnleft", false, "Show the close button on the left")
+var showCloseButtonLeft = flag.Bool("closebtnleft", false, "Show the close button on the left")
 var debug = flag.Bool("d", false, "Turn on Debug messages")
 
 func main() {
@@ -540,7 +540,7 @@ func main() {
 	outerVBox := gtk.NewBox(gtk.OrientationVertical, 0)
 	win.Add(outerVBox)
 
-  closeButtonBox := createCloseButtonBox(*showCloseButton, *closeButtonLeft)
+  closeButtonBox := createCloseButtonBox((*showCloseButton || *showCloseButtonLeft), *showCloseButtonLeft)
   if closeButtonBox != nil {
     outerVBox.PackStart(closeButtonBox, false, false, 10)
   }

--- a/main.go
+++ b/main.go
@@ -184,6 +184,8 @@ var pbReboot = flag.String("pbreboot", "", "command for the Reboot power bar ico
 var pbSleep = flag.String("pbsleep", "", "command for the sleep power bar icon")
 var pbSize = flag.Int("pbsize", 64, "power bar icon size (only works w/ built-in icons)")
 var pbUseIconTheme = flag.Bool("pbuseicontheme", false, "use icon theme instead of built-in icons in power bar")
+var showCloseButton = flag.Bool("closebtn", false, "Show the close button")
+var closeButtonLeft = flag.Bool("closebtnleft", false, "Show the close button on the left")
 var debug = flag.Bool("d", false, "Turn on Debug messages")
 
 func main() {
@@ -533,9 +535,15 @@ func main() {
 		win.Maximize()
 	}
 
+
 	// Set up UI
 	outerVBox := gtk.NewBox(gtk.OrientationVertical, 0)
 	win.Add(outerVBox)
+
+  closeButtonBox := createCloseButtonBox(*showCloseButton, *closeButtonLeft)
+  if closeButtonBox != nil {
+    outerVBox.PackStart(closeButtonBox, false, false, 10)
+  }
 
 	searchBoxWrapper := gtk.NewBox(gtk.OrientationHorizontal, 0)
 	outerVBox.PackStart(searchBoxWrapper, false, false, 10)

--- a/main.go
+++ b/main.go
@@ -184,8 +184,7 @@ var pbReboot = flag.String("pbreboot", "", "command for the Reboot power bar ico
 var pbSleep = flag.String("pbsleep", "", "command for the sleep power bar icon")
 var pbSize = flag.Int("pbsize", 64, "power bar icon size (only works w/ built-in icons)")
 var pbUseIconTheme = flag.Bool("pbuseicontheme", false, "use icon theme instead of built-in icons in power bar")
-var showCloseButton = flag.Bool("closebtn", false, "Show the close button")
-var showCloseButtonLeft = flag.Bool("closebtnleft", false, "Show the close button on the left")
+var closeBtn = flag.String("closebtn", "none", "close button position: 'left' or 'right', 'none' by default")
 var debug = flag.Bool("d", false, "Turn on Debug messages")
 
 func main() {
@@ -540,7 +539,7 @@ func main() {
 	outerVBox := gtk.NewBox(gtk.OrientationVertical, 0)
 	win.Add(outerVBox)
 
-  closeButtonBox := createCloseButtonBox((*showCloseButton || *showCloseButtonLeft), *showCloseButtonLeft)
+  closeButtonBox := createCloseButtonBox((*closeBtn != "none"), (*closeBtn != "right"))
   if closeButtonBox != nil {
     outerVBox.PackStart(closeButtonBox, false, false, 10)
   }

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -345,11 +345,6 @@ func createCloseButtonBox(show bool, alignLeft bool) *gtk.Box {
   }
 
   buttonBox := gtk.NewBox(gtk.OrientationHorizontal, 0)
-  if alignLeft {
-    buttonBox.SetHAlign(gtk.AlignStart)
-  } else {
-    buttonBox.SetHAlign(gtk.AlignEnd)
-  }
 
   closeButton := gtk.NewButtonFromIconName("window-close-symbolic", int(gtk.IconSizeMenu))
   closeButton.SetRelief(gtk.ReliefNone)
@@ -360,8 +355,10 @@ func createCloseButtonBox(show bool, alignLeft bool) *gtk.Box {
   })
 
   if alignLeft {
+    buttonBox.SetHAlign(gtk.AlignStart)
     buttonBox.PackStart(closeButton, false, false, 10)
   } else {
+    buttonBox.SetHAlign(gtk.AlignEnd)
     buttonBox.PackEnd(closeButton, false, false, 10)
   }  
   return buttonBox

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -339,6 +339,34 @@ func powerButton(iconPathOrName, command string) *gtk.Button {
 	return button
 }
 
+func createCloseButtonBox(show bool, alignLeft bool) *gtk.Box {
+  if (!show) {
+    return nil
+  }
+
+  buttonBox := gtk.NewBox(gtk.OrientationHorizontal, 0)
+  if alignLeft {
+    buttonBox.SetHAlign(gtk.AlignStart)
+  } else {
+    buttonBox.SetHAlign(gtk.AlignEnd)
+  }
+
+  closeButton := gtk.NewButtonFromIconName("window-close-symbolic", int(gtk.IconSizeMenu))
+  closeButton.SetRelief(gtk.ReliefNone)
+  closeButton.SetObjectProperty("name", "close-button")
+
+  closeButton.Connect("clicked", func() {
+      gtk.MainQuit()
+  })
+
+  if alignLeft {
+    buttonBox.PackStart(closeButton, false, false, 10)
+  } else {
+    buttonBox.PackEnd(closeButton, false, false, 10)
+  }  
+  return buttonBox
+}
+
 func setUpFileSearchResultContainer() *gtk.FlowBox {
 	if fileSearchResultFlowBox != nil {
 		fileSearchResultFlowBox.Destroy()
@@ -602,6 +630,10 @@ func setUpOperationResultWindow(operation string, result string) {
 
 	outerVBox := gtk.NewBox(gtk.OrientationVertical, 6)
 	window.Add(outerVBox)
+
+  // close button mainly for touch users
+  //closeButtonBox := createCloseButtonBox()
+  //outerVBox.PackStart(closeButtonBox, false, false, 10)
 
 	vBox := gtk.NewBox(gtk.OrientationHorizontal, 5)
 	outerVBox.PackStart(vBox, true, true, 6)

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -631,10 +631,6 @@ func setUpOperationResultWindow(operation string, result string) {
 	outerVBox := gtk.NewBox(gtk.OrientationVertical, 6)
 	window.Add(outerVBox)
 
-  // close button mainly for touch users
-  //closeButtonBox := createCloseButtonBox()
-  //outerVBox.PackStart(closeButtonBox, false, false, 10)
-
 	vBox := gtk.NewBox(gtk.OrientationHorizontal, 5)
 	outerVBox.PackStart(vBox, true, true, 6)
 	lbl := gtk.NewLabel(fmt.Sprintf("%s = %s", operation, result))


### PR DESCRIPTION
I am aware that you can toggle the drawer by running the command again, however this resolution is insufficient in some cases.
This pull implements a simple close button which the user can enable and change the position of with launch parameters:

-~~`nwg-drawer -closebtn` - adds a simple close button in the top right of the drawer~~
-~~`nwg-drawer -closebtn -closebtnleft` - obvious~~

~~- `nwg-drawer -closebtn` to add a close button to the top right of the drawer, `nwg-drawer -closebtnleft` to add to the top left.~~

- `-closebtn position` close button position: 'left' or 'right', 'none' by default

If any changes need to be made I will fix it asap.
Thanks!