### PR TITLE
Add flags to set custom labels for power buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,26 @@ Usage of nwg-drawer:
     	use OVerLay layer
   -pbexit string
     	command for the Exit power bar icon
+  -pbexitlabel string
+    	label for the Exit power bar icon
   -pblock string
     	command for the Lock power bar icon
+  -pblocklabel string
+    	label for the Lock power bar icon
   -pbpoweroff string
     	command for the Poweroff power bar icon
+  -pbpowerofflabel string
+    	label for the Poweroff power bar icon
   -pbreboot string
     	command for the Reboot power bar icon
+  -pbrebootlabel string
+    	label for the Reboot power bar icon
   -pbsize int
     	power bar icon size (only works w/ built-in icons) (default 64)
   -pbsleep string
     	command for the sleep power bar icon
+  -pbsleeplabel string
+    	label for the sleep power bar icon
   -pbuseicontheme
     	use icon theme instead of built-in icons in power bar
   -r	Leave the program resident in memory

--- a/main.go
+++ b/main.go
@@ -187,10 +187,15 @@ var noCats = flag.Bool("nocats", false, "Disable filtering by category")
 var noFS = flag.Bool("nofs", false, "Disable file search")
 var resident = flag.Bool("r", false, "Leave the program resident in memory")
 var pbExit = flag.String("pbexit", "", "command for the Exit power bar icon")
+var pbExitLabel = flag.String("pbexitlabel", "", "label for the Exit power bar icon")
 var pbLock = flag.String("pblock", "", "command for the Lock power bar icon")
+var pbLockLabel = flag.String("pblocklabel", "", "label for the Lock power bar icon")
 var pbPoweroff = flag.String("pbpoweroff", "", "command for the Poweroff power bar icon")
+var pbPoweroffLabel = flag.String("pbpowerofflabel", "", "label for the Poweroff power bar icon")
 var pbReboot = flag.String("pbreboot", "", "command for the Reboot power bar icon")
+var pbRebootLabel = flag.String("pbrebootlabel", "", "label for the Reboot power bar icon")
 var pbSleep = flag.String("pbsleep", "", "command for the sleep power bar icon")
+var pbSleepLabel = flag.String("pbsleeplabel", "", "label for the sleep power bar icon")
 var pbSize = flag.Int("pbsize", 64, "power bar icon size (only works w/ built-in icons)")
 var pbUseIconTheme = flag.Bool("pbuseicontheme", false, "use icon theme instead of built-in icons in power bar")
 var closeBtn = flag.String("closebtn", "none", "close button position: 'left' or 'right', 'none' by default")
@@ -665,9 +670,9 @@ func main() {
 			if *pbPoweroff != "" {
 				btn := gtk.NewButton()
 				if !*pbUseIconTheme {
-					btn = powerButton(filepath.Join(dataDirectory, "img/poweroff.svg"), *pbPoweroff)
+					btn = powerButton(filepath.Join(dataDirectory, "img/poweroff.svg"), *pbPoweroff, *pbPoweroffLabel)
 				} else {
-					btn = powerButton("system-shutdown-symbolic", *pbPoweroff)
+					btn = powerButton("system-shutdown-symbolic", *pbPoweroff, *pbPoweroffLabel)
 				}
 				powerButtonsWrapper.PackEnd(btn, true, false, 0)
 				firstPowerBtn = btn
@@ -675,9 +680,9 @@ func main() {
 			if *pbSleep != "" {
 				btn := gtk.NewButton()
 				if !*pbUseIconTheme {
-					btn = powerButton(filepath.Join(dataDirectory, "img/sleep.svg"), *pbSleep)
+					btn = powerButton(filepath.Join(dataDirectory, "img/sleep.svg"), *pbSleep, *pbSleepLabel)
 				} else {
-					btn = powerButton("face-yawn-symbolic", *pbSleep)
+					btn = powerButton("face-yawn-symbolic", *pbSleep, *pbSleepLabel)
 				}
 				powerButtonsWrapper.PackEnd(btn, true, false, 0)
 				firstPowerBtn = btn
@@ -685,9 +690,9 @@ func main() {
 			if *pbReboot != "" {
 				btn := gtk.NewButton()
 				if !*pbUseIconTheme {
-					btn = powerButton(filepath.Join(dataDirectory, "img/reboot.svg"), *pbReboot)
+					btn = powerButton(filepath.Join(dataDirectory, "img/reboot.svg"), *pbReboot, *pbRebootLabel)
 				} else {
-					btn = powerButton("system-reboot-symbolic", *pbReboot)
+					btn = powerButton("system-reboot-symbolic", *pbReboot, *pbRebootLabel)
 				}
 				powerButtonsWrapper.PackEnd(btn, true, false, 0)
 				firstPowerBtn = btn
@@ -695,9 +700,9 @@ func main() {
 			if *pbExit != "" {
 				btn := gtk.NewButton()
 				if !*pbUseIconTheme {
-					btn = powerButton(filepath.Join(dataDirectory, "img/exit.svg"), *pbExit)
+					btn = powerButton(filepath.Join(dataDirectory, "img/exit.svg"), *pbExit, *pbExitLabel)
 				} else {
-					btn = powerButton("system-log-out-symbolic", *pbExit)
+					btn = powerButton("system-log-out-symbolic", *pbExit, *pbExitLabel)
 				}
 				powerButtonsWrapper.PackEnd(btn, true, false, 0)
 				firstPowerBtn = btn
@@ -705,9 +710,9 @@ func main() {
 			if *pbLock != "" {
 				btn := gtk.NewButton()
 				if !*pbUseIconTheme {
-					btn = powerButton(filepath.Join(dataDirectory, "img/lock.svg"), *pbLock)
+					btn = powerButton(filepath.Join(dataDirectory, "img/lock.svg"), *pbLock, *pbLockLabel)
 				} else {
-					btn = powerButton("system-lock-screen-symbolic", *pbLock)
+					btn = powerButton("system-lock-screen-symbolic", *pbLock, *pbLockLabel)
 				}
 				powerButtonsWrapper.PackEnd(btn, true, false, 0)
 				firstPowerBtn = btn

--- a/uicomponents.go
+++ b/uicomponents.go
@@ -320,7 +320,7 @@ func flowBoxButton(entry desktopEntry) *gtk.Button {
 	return button
 }
 
-func powerButton(iconPathOrName, command string) *gtk.Button {
+func powerButton(iconPathOrName, command, label string) *gtk.Button {
 	button := gtk.NewButton()
 	button.SetAlwaysShowImage(true)
 
@@ -353,13 +353,21 @@ func powerButton(iconPathOrName, command string) *gtk.Button {
 		launch(command, false, true)
 	})
 	button.Connect("enter-notify-event", func() {
-		statusLabel.SetText(command)
+		if label != "" {
+			statusLabel.SetText(label)
+		} else {
+			statusLabel.SetText(command)
+		}
 	})
 	button.Connect("leave-notify-event", func() {
 		statusLabel.SetText("")
 	})
 	button.Connect("focus-in-event", func() {
-		statusLabel.SetText(command)
+		if label != "" {
+			statusLabel.SetText(label)
+		} else {
+			statusLabel.SetText(command)
+		}
 	})
 	return button
 }


### PR DESCRIPTION
Currently, the power row buttons always use the command as the label; this could be confusing in some cases, e.g. when a long/confusing command is used and an end user (such as someone using a system config provided by the desktop/distro) is trying to figure out what button does what. This adds a new set of flags to set the labels for each of the power buttons, which should address this.